### PR TITLE
Support for IU redeployment

### DIFF
--- a/org.sonatype.p2.bridge.impl/src/main/java/org/sonatype/p2/bridge/internal/ArtifactRepositoryService.java
+++ b/org.sonatype.p2.bridge.impl/src/main/java/org/sonatype/p2/bridge/internal/ArtifactRepositoryService.java
@@ -426,7 +426,14 @@ public class ArtifactRepositoryService
             destinationManager = getManager( null );
             final IArtifactRepository destinationRepository = getRepository( destinationManager, destination );
 
-            destinationRepository.addDescriptors( descriptorsQuery.toArray( IArtifactDescriptor.class ), monitor );
+            final IArtifactDescriptor[] newDescriptors = descriptorsQuery.toArray( IArtifactDescriptor.class );
+            // remove the old descriptors to avoid stale data (otherwise the artifact and p2 metadata don't match)
+            // as we are not living in a 'perfect' world redeploying of an IU with the same version may happen
+            for ( IArtifactDescriptor d : newDescriptors )
+            {
+                destinationRepository.removeDescriptor( d.getArtifactKey(), monitor );
+            }
+            destinationRepository.addDescriptors( newDescriptors, monitor );
         }
         catch ( final ProvisionException e )
         {

--- a/org.sonatype.p2.bridge.impl/src/main/java/org/sonatype/p2/bridge/internal/MetadataRepositoryService.java
+++ b/org.sonatype.p2.bridge.impl/src/main/java/org/sonatype/p2/bridge/internal/MetadataRepositoryService.java
@@ -334,7 +334,11 @@ public class MetadataRepositoryService
             destinationManager = getManager( null );
             final IMetadataRepository destinationRepository = getRepository( destinationManager, destination );
 
-            destinationRepository.addInstallableUnits( unitsQuery.toSet() );
+            final Set<IInstallableUnit> newUnits = unitsQuery.toSet();
+            // remove the old descriptors to avoid stale data (otherwise the artifact and p2 metadata don't match)
+            // as we are not living in a 'perfect' world redeploying of an IU with the same version may happen
+            destinationRepository.removeInstallableUnits( newUnits );
+            destinationRepository.addInstallableUnits( newUnits );
         }
         catch ( final ProvisionException e )
         {


### PR DESCRIPTION
This commit allows for redeployment of an IU.
The redeployment of an IU should not happen according to the p2 'specification' but as the underlying maven repository may support such an redeployment this could lead to an invalid p2 repo (repo points to latest artifact but contain still the old checksum etc.).
